### PR TITLE
URI extension method to add parameters

### DIFF
--- a/src/UriExtensions/UriExtensions.cs
+++ b/src/UriExtensions/UriExtensions.cs
@@ -1,0 +1,18 @@
+
+using System;
+using System.Web;
+
+namespace EduitorNetCore.UriExtensionMethods
+{
+    public static class UriExtensions
+    {
+        public static Uri AddParameter(this Uri url, string paramName, string paramValue)
+        {
+            var uriBuilder = new UriBuilder(url);
+            var query = HttpUtility.ParseQueryString(uriBuilder.Query);
+            query[paramName] = paramValue;
+            uriBuilder.Query = query.ToString();
+            return uriBuilder.Uri;
+        }
+    }
+}


### PR DESCRIPTION
## Summary:
 Adding a parameter to a uri using the existing URI class is verbose and long-winded. A new class was added that provides and extension method for adding these parameters in a simple way.

## Sample usage:

    URI uri = new URI(Client.BaseAddress + ControllerBaseURL)
                .AddParameter("categoryId", "0")
                .AddParameter("ageRangeId", "0")
                .AddParameter("pageSize", $"{count}");